### PR TITLE
Prepare for release v1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Sia Antfarm Docker Image Changelog
 
+## Feb 22, 2021:
+### v1.1.0
+**Key Updates**
+- Update Docker image to use Sia Antfarm `v1.1.0` which uses Sia `v1.5.4`.
+
 ## Nov 18, 2020:
 ### v1.0.5
 **Key Updates**

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN apt update && \
 RUN mkdir -p sia-antfarm/data
 
 # Download sia-antfarm and siad-dev binaries
-ARG SIA_ANTFARM_VERSION=v1.0.4
+ARG SIA_ANTFARM_VERSION=v1.1.0
 WORKDIR /sia-antfarm
 RUN curl -o tag-page.html --fail "https://gitlab.com/NebulousLabs/Sia-Ant-Farm/-/tags/${SIA_ANTFARM_VERSION}" && \
     download_link="https://gitlab.com$(cat tag-page.html | grep job=build | grep -Po '(?<=href=\")[^\"]*')" && \

--- a/README.md
+++ b/README.md
@@ -11,20 +11,23 @@
 ### Latest
 * **latest**
 
+### v1.1.0
+* Sia AntFarm `v1.1.0` based on Sia `v1.5.4`
+
 ### v1.0.5
 * Allows publishing multiple ant HTTP API ports
 
 ### v1.0.4
-* Sia Ant Farm `v1.0.4` based on Sia `v.1.5.3`
+* Sia Ant Farm `v1.0.4` based on Sia `v1.5.3`
 
 ### v1.0.3
-* Sia Ant Farm `v1.0.3` based on Sia `v.1.5.2`
+* Sia Ant Farm `v1.0.3` based on Sia `v1.5.2`
 
 ### v1.0.2
-* Sia Ant Farm `v1.0.2` based on Sia `v.1.5.1`
+* Sia Ant Farm `v1.0.2` based on Sia `v1.5.1`
 
 ### v1.0.1
-* Sia Ant Farm `v1.0.1` based on Sia `v.1.5.0`
+* Sia Ant Farm `v1.0.1` based on Sia `v1.5.0`
 
 ## Running Ant Farm in Docker container
 

--- a/changelog/changelog-tail.md
+++ b/changelog/changelog-tail.md
@@ -1,3 +1,8 @@
+## Feb 22, 2021:
+### v1.1.0
+**Key Updates**
+- Update Docker image to use Sia Antfarm `v1.1.0` which uses Sia `v1.5.4`.
+
 ## Nov 18, 2020:
 ### v1.0.5
 **Key Updates**


### PR DESCRIPTION
Update repo for releasing docker image `v1.1.0` using Sia Antfarm `v1.1.0`.